### PR TITLE
Lock_inside_contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# Hedgey Variable Token NFT Contracts
+# Hedgey Streaming and Vesting Token NFT Contracts

--- a/contracts/StreamVestingNFT.sol
+++ b/contracts/StreamVestingNFT.sol
@@ -188,6 +188,17 @@ contract StreamVestingNFT is ERC721Enumerable, ReentrancyGuard {
     }
   }
 
+  function streamBalanceAtTime(uint256 tokenId, uint256 time) public view returns (uint256 balance, uint256 remainder) {
+    Stream memory stream = streams[tokenId];
+    if (stream.start >= time || stream.cliffDate >= time) {
+      remainder = stream.amount;
+    } else {
+      /// @dev balance is just the number of seconds passed times the rate of tokens streamed per second, up to the total amount, ie min of the two
+      balance = StreamLibrary.min((time - stream.start) * stream.rate, stream.amount);
+      remainder = stream.amount - balance;
+    }
+  }
+
   function getStreamEnd(uint256 tokenId) public view returns (uint256 end) {
     Stream memory stream = streams[tokenId];
     end = StreamLibrary.endDate(stream.start, stream.rate, stream.amount);

--- a/contracts/StreamVestingNFT.sol
+++ b/contracts/StreamVestingNFT.sol
@@ -6,6 +6,7 @@ import '@openzeppelin/contracts/utils/Counters.sol';
 import '@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol';
 import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
 import './libraries/TransferHelper.sol';
+import './libraries/StreamLibrary.sol';
 
 /**
  * @title An NFT representation of ownership of time locked tokens
@@ -99,7 +100,7 @@ contract StreamVestingNFT is ERC721Enumerable, ReentrancyGuard {
     require(rate > 0 && rate <= amount);
     _tokenIds.increment();
     uint256 newItemId = _tokenIds.current();
-    uint256 end = endDate(start, rate, amount);
+    uint256 end = StreamLibrary.endDate(start, rate, amount);
     lockedBalance[holder][token] += amount;
     TransferHelper.transferTokens(token, msg.sender, address(this), amount);
     streams[newItemId] = Stream(token, amount, start, cliffDate, rate, manager);
@@ -107,36 +108,19 @@ contract StreamVestingNFT is ERC721Enumerable, ReentrancyGuard {
     emit NFTCreated(newItemId, holder, token, amount, start, cliffDate, end, rate, manager);
   }
 
-  function revokeNFT(uint256 tokenId, address fundsRecipient) external nonReentrant {
-    Stream memory stream = streams[tokenId];
-    require(stream.manager == msg.sender, 'not manager');
-    (uint256 balance, uint256 remainder) = streamBalanceOf(tokenId);
-    address holder = ownerOf(tokenId);
-    lockedBalance[holder][stream.token] -= stream.amount;
-    delete streams[tokenId];
-    _burn(tokenId);
-    TransferHelper.withdrawTokens(stream.token, fundsRecipient, remainder);
-    TransferHelper.withdrawTokens(stream.token, holder, balance);
-    emit NFTRevoked(tokenId, remainder, balance);
-  }
-
-  /// @notice this is the external function that actually redeems an NFT position
-  /// @notice returns true if the function is successful
-  /// @dev this function calls the _redeemFuture(...) internal function which handles the requirements and checks
-  function redeemNFT(uint256 tokenId) external nonReentrant returns (bool) {
-    /// @dev calls the internal _redeemNFT function that performs various checks to ensure that only the owner of the NFT can redeem their NFT and Future position
-    _redeemNFT(msg.sender, tokenId);
-    return true;
-  }
-
-  function bulkRedeem(uint256[] memory tokenIds) external nonReentrant {
+  function redeemNFT(uint256[] memory tokenIds) external nonReentrant {
     for (uint256 i; i < tokenIds.length; i++) {
       _redeemNFT(msg.sender, tokenIds[i]);
     }
   }
 
+  function revokeNFT(uint256[] memory tokenIds, address fundsRecipient) external nonReentrant {
+    for (uint256 i; i < tokenIds.length; i++) {
+      _revokeNFT(msg.sender, tokenIds[i], fundsRecipient);
+    }
+  }
+
   function _redeemNFT(address holder, uint256 tokenId) internal returns (uint256 balance, uint256 remainder) {
-    /// @dev ensure that only the owner of the NFT can call this function
     require(ownerOf(tokenId) == holder, 'NFT03');
     Stream memory stream = streams[tokenId];
     (balance, remainder) = streamBalanceOf(tokenId);
@@ -147,14 +131,28 @@ contract StreamVestingNFT is ERC721Enumerable, ReentrancyGuard {
       _burn(tokenId);
       emit NFTRedeemed(tokenId, balance);
     } else {
-      // resets the amount
       streams[tokenId].amount -= balance;
-      // sets the start date to now so that the remaining balance starts streaming again starting now
       streams[tokenId].start = block.timestamp;
       emit NFTPartiallyRedeemed(tokenId, remainder, balance);
     }
-    // deliver the requested token balance to the holder
     TransferHelper.withdrawTokens(stream.token, holder, balance);
+  }
+
+  function _revokeNFT(
+    address manager,
+    uint256 tokenId,
+    address fundsRecipient
+  ) internal {
+    Stream memory stream = streams[tokenId];
+    require(stream.manager == manager, 'not manager');
+    (uint256 balance, uint256 remainder) = streamBalanceOf(tokenId);
+    address holder = ownerOf(tokenId);
+    lockedBalance[holder][stream.token] -= stream.amount;
+    delete streams[tokenId];
+    _burn(tokenId);
+    TransferHelper.withdrawTokens(stream.token, fundsRecipient, remainder);
+    TransferHelper.withdrawTokens(stream.token, holder, balance);
+    emit NFTRevoked(tokenId, remainder, balance);
   }
 
   function _transfer(
@@ -171,25 +169,25 @@ contract StreamVestingNFT is ERC721Enumerable, ReentrancyGuard {
       remainder = stream.amount;
     } else {
       /// @dev balance is just the number of seconds passed times the rate of tokens streamed per second, up to the total amount, ie min of the two
-      balance = min((block.timestamp - stream.start) * stream.rate, stream.amount);
+      balance = StreamLibrary.min((block.timestamp - stream.start) * stream.rate, stream.amount);
       remainder = stream.amount - balance;
     }
   }
 
   function getStreamEnd(uint256 tokenId) public view returns (uint256 end) {
     Stream memory stream = streams[tokenId];
-    end = endDate(stream.start, stream.rate, stream.amount);
+    end = StreamLibrary.endDate(stream.start, stream.rate, stream.amount);
   }
 
-  function endDate(
-    uint256 start,
-    uint256 rate,
-    uint256 amount
-  ) public pure returns (uint256 end) {
-    end = (amount / rate) + start;
-  }
+  // function endDate(
+  //   uint256 start,
+  //   uint256 rate,
+  //   uint256 amount
+  // ) public pure returns (uint256 end) {
+  //   end = (amount / rate) + start;
+  // }
 
-  function min(uint256 a, uint256 b) public pure returns (uint256 _min) {
-    _min = (a <= b) ? a : b;
-  }
+  // function min(uint256 a, uint256 b) public pure returns (uint256 _min) {
+  //   _min = (a <= b) ? a : b;
+  // }
 }

--- a/contracts/StreamVestingNFT.sol
+++ b/contracts/StreamVestingNFT.sol
@@ -93,7 +93,7 @@ contract StreamVestingNFT is ERC721Enumerable, ReentrancyGuard {
     uint256 rate,
     address manager
   ) external nonReentrant {
-    require(holder != address(0) && manager != address(0));
+    require(holder != address(0));
     require(token != address(0));
     require(amount > 0);
     require(rate > 0 && rate <= amount);

--- a/contracts/StreamVestingNFT.sol
+++ b/contracts/StreamVestingNFT.sol
@@ -179,24 +179,13 @@ contract StreamVestingNFT is ERC721Enumerable, ReentrancyGuard {
 
   function streamBalanceOf(uint256 tokenId) public view returns (uint256 balance, uint256 remainder) {
     Stream memory stream = streams[tokenId];
-    if (stream.start >= block.timestamp || stream.cliffDate >= block.timestamp) {
-      remainder = stream.amount;
-    } else {
-      /// @dev balance is just the number of seconds passed times the rate of tokens streamed per second, up to the total amount, ie min of the two
-      balance = StreamLibrary.min((block.timestamp - stream.start) * stream.rate, stream.amount);
-      remainder = stream.amount - balance;
-    }
-  }
-
-  function streamBalanceAtTime(uint256 tokenId, uint256 time) public view returns (uint256 balance, uint256 remainder) {
-    Stream memory stream = streams[tokenId];
-    if (stream.start >= time || stream.cliffDate >= time) {
-      remainder = stream.amount;
-    } else {
-      /// @dev balance is just the number of seconds passed times the rate of tokens streamed per second, up to the total amount, ie min of the two
-      balance = StreamLibrary.min((time - stream.start) * stream.rate, stream.amount);
-      remainder = stream.amount - balance;
-    }
+    (balance, remainder) = StreamLibrary.streamBalanceAtTime(
+      stream.start,
+      stream.cliffDate,
+      stream.amount,
+      stream.rate,
+      block.timestamp
+    );
   }
 
   function getStreamEnd(uint256 tokenId) public view returns (uint256 end) {

--- a/contracts/StreamingNFT.sol
+++ b/contracts/StreamingNFT.sol
@@ -119,6 +119,19 @@ contract StreamingHedgeys is ERC721Enumerable, ReentrancyGuard {
     }
   }
 
+  /// @notice function to claim for all of my owned NFTs
+  /// @dev pulls the balance and uses the enumerate function to redeem each NFT based on their index id
+  function redeemMyNFTs() external nonReentrant {
+    for (uint256 i; i < balanceOf(msg.sender); i++) {
+      //check the balance of the vest first
+      uint tokenId = tokenOfOwnerByIndex(msg.sender, i);
+      (uint balance,) = streamBalanceOf(tokenId);
+      if (balance > 0) {
+        _redeemNFT(msg.sender, tokenId);
+      }
+    }
+  }
+
   function _redeemNFT(address holder, uint256 tokenId) internal returns (uint256 remainder) {
     require(ownerOf(tokenId) == holder, 'NFT03');
     Stream memory stream = streams[tokenId];

--- a/contracts/StreamingNFT.sol
+++ b/contracts/StreamingNFT.sol
@@ -144,15 +144,4 @@ contract StreamingHedgeys is ERC721Enumerable, ReentrancyGuard {
     end = StreamLibrary.endDate(stream.start, stream.rate, stream.amount);
   }
 
-  // function endDate(
-  //   uint256 start,
-  //   uint256 rate,
-  //   uint256 amount
-  // ) public pure returns (uint256 end) {
-  //   end = (amount / rate) + start;
-  // }
-
-  // function min(uint256 a, uint256 b) public pure returns (uint256 _min) {
-  //   _min = (a <= b) ? a : b;
-  // }
 }

--- a/contracts/interfaces/INFT.sol
+++ b/contracts/interfaces/INFT.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.17;
+
+/// @dev this is the one contract call that the OTC needs to interact with the NFT contract
+interface INFT {
+  /// @notice function for publicly viewing a lockedToken (future) details
+  /// @param _id is the id of the NFT which is mapped to the future struct
+  /// @dev this returns the amount of tokens locked, the token address and the date that they are unlocked
+  function futures(uint256 _id)
+    external
+    view
+    returns (
+      uint256 amount,
+      address token,
+      uint256 unlockDate
+    );
+
+  /// @param _holder is the new owner of the NFT and timelock future - this can be any address
+  /// @param _amount is the amount of tokens that are going to be locked
+  /// @param _token is the token address to be locked by the NFT. Use WETH address for ETH - but WETH must be held by the msg.sender
+  /// ... as there is no automatic wrapping from ETH to WETH for this function.
+  /// @param _unlockDate is the date which the tokens become unlocked and available to be redeemed and withdrawn from the contract
+  /// @dev this is a public function that anyone can call
+  /// @dev the _holder can be defined as your address, or any chose address - and so you can directly mint NFTs to other addresses
+  /// ... in a way to airdrop NFTs directly to contributors
+  function createNFT(
+    address _holder,
+    uint256 _amount,
+    address _token,
+    uint256 _unlockDate
+  ) external returns (uint256);
+
+  /// @dev function for redeeming an NFT
+  /// @notice this function will burn the NFT and delete the future struct - in return the locked tokens will be delivered
+  function redeemNFT(uint256 _id) external returns (bool);
+
+  /// @notice this event spits out the details of the NFT and future struct when a new NFT & Future is minted
+  event NFTCreated(uint256 _i, address _holder, uint256 _amount, address _token, uint256 _unlockDate);
+
+  /// @notice this event spits out the details of the NFT and future structe when an existing NFT and Future is redeemed
+  event NFTRedeemed(uint256 _i, address _holder, uint256 _amount, address _token, uint256 _unlockDate);
+
+  /// @notice this event is fired the one time when the baseURI is updated
+  event URISet(string newURI);
+}

--- a/contracts/libraries/NFTHelper.sol
+++ b/contracts/libraries/NFTHelper.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.17;
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import '../interfaces/INFT.sol';
+
+/// @notice Library to lock tokens and mint an NFT
+/// @notice this NFTHelper is used by the HedgeyOTC contract to lock tokens and instruct the Hedgeys contract to mint an NFT
+library NFTHelper {
+  /// @dev internal function that handles the locking of the tokens in the NFT Futures contract
+  /// @param futureContract is the address of the NFT contract that will mint the NFT and lock tokens
+  /// @param _holder address here becomes the owner of the newly minted NFT
+  /// @param _token address here is the ERC20 contract address of the tokens being locked by the NFT contract
+  /// @param _amount is the amount of tokens that will be locked
+  /// @param _unlockDate provides the unlock date which is the expiration date for the Future generated
+  function lockTokens(
+    address futureContract,
+    address _holder,
+    address _token,
+    uint256 _amount,
+    uint256 _unlockDate
+  ) internal {
+    /// @dev ensure that the _unlockDate is in the future compared to the current block timestamp
+    require(_unlockDate > block.timestamp, 'NHL01');
+    /// @dev similar to checking the balances for the OTC contract when creating a new deal - we check the current and post balance in the NFT contract
+    /// @dev to ensure that 100% of the amount of tokens to be locked are in fact locked in the contract address
+    uint256 currentBalance = IERC20(_token).balanceOf(futureContract);
+    /// @dev increase allowance so that the NFT contract can pull the total funds
+    /// @dev this is a safer way to ensure that the entire amount is delivered to the NFT contract
+    SafeERC20.safeIncreaseAllowance(IERC20(_token), futureContract, _amount);
+    /// @dev this function points to the NFT Futures contract and calls its function to mint an NFT and generate the locked tokens future struct
+    INFT(futureContract).createNFT(_holder, _amount, _token, _unlockDate);
+    /// @dev check to make sure that _holder is received by the futures contract equals the total amount we have delivered
+    /// @dev this prevents functionality with deflationary or tax tokens that have not whitelisted these address
+    uint256 postBalance = IERC20(_token).balanceOf(futureContract);
+    require(postBalance - currentBalance == _amount);
+  }
+}

--- a/contracts/libraries/StreamLibrary.sol
+++ b/contracts/libraries/StreamLibrary.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.17;
 
 library StreamLibrary {
-  function min(uint256 a, uint256 b) external pure returns (uint256 _min) {
+  function min(uint256 a, uint256 b) public pure returns (uint256 _min) {
     _min = (a <= b) ? a : b;
   }
 
@@ -10,7 +10,22 @@ library StreamLibrary {
     uint256 start,
     uint256 rate,
     uint256 amount
-  ) external pure returns (uint256 end) {
+  ) public pure returns (uint256 end) {
     end = (amount / rate) + start;
+  }
+
+  function streamBalanceAtTime(
+    uint256 start,
+    uint256 cliff,
+    uint256 amount,
+    uint256 rate,
+    uint256 time
+  ) public pure returns (uint256 balance, uint256 remainder) {
+    if (start >= time || cliff >= time) {
+      remainder = amount;
+    } else {
+      balance = min((time - start) * rate, amount);
+      remainder = amount - balance;
+    }
   }
 }

--- a/contracts/test/FuturesNFT.sol
+++ b/contracts/test/FuturesNFT.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.17;
+
+import '@openzeppelin/contracts/token/ERC721/ERC721.sol';
+import '@openzeppelin/contracts/utils/Counters.sol';
+import '@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol';
+import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
+import '../libraries/TransferHelper.sol';
+
+/**
+ * @title An NFT representation of ownership of time locked tokens
+ * @notice The time locked tokens are redeemable by the owner of the NFT
+ * @notice The NFT is basic ERC721 with an ownable usage to ensure only a single owner call mint new NFTs
+ * @notice it uses the Enumerable extension to allow for easy lookup to pull balances of one account for multiple NFTs
+ */
+contract Hedgeys is ERC721Enumerable, ReentrancyGuard {
+  using SafeERC20 for IERC20;
+  using Counters for Counters.Counter;
+  Counters.Counter private _tokenIds;
+
+  /// @dev handles weth in case WETH is being held - this allows us to unwrap and deliver ETH upon redemption of a timelocked NFT with ETH
+  address payable public weth;
+  /// @dev baseURI is the URI directory where the metadata is stored
+  string private baseURI;
+  /// @dev this is a counter used so that the baseURI can only be set once after deployment
+  uint8 private uriSet = 0;
+
+  /// @dev the Future is the storage in a struct of the tokens that are time locked
+  /// @dev the Future contains the information about the amount of tokens, the underlying token address (asset), and the date in which they are unlocked
+  struct Future {
+    uint256 amount;
+    address token;
+    uint256 unlockDate;
+  }
+
+  /// @dev this maping maps the _tokenIDs from Counters to a Future struct. the same _tokenIDs that is set for the NFT id is mapped to the futures
+  mapping(uint256 => Future) public futures;
+
+  constructor(address payable _weth, string memory uri) ERC721('Hedgeys', 'HDGY') {
+    weth = _weth;
+    baseURI = uri;
+  }
+
+  receive() external payable {}
+
+  /**
+   * @notice The external function creates a Future position
+   * @notice This function does not accept ETH, must send in WETH to lock ETH
+   * @notice A Future position is the combination of an NFT and a Future struct with the same _tokenID storing both information separately but with the same index
+   * @notice Anyone can mint an NFT & create a futures Struct, so long as they have sufficient tokens to lock up
+   * @notice A user can mint the NFT to themselves, passing in their address to the first parameter, or they can directly mint an NFT to someone else
+   * @param _holder is the owner of the minted NFT and the owner of the locked tokens
+   * @param _amount is the amount with full decimals of the tokens being locked into the future
+   * @param _token is the address of the tokens that are being delivered to this contract to be held and locked
+   * @param _unlockDate is the date in UTC in which the tokens can become redeemed - evaluated based on the block.timestamp
+   */
+  function createNFT(
+    address _holder,
+    uint256 _amount,
+    address _token,
+    uint256 _unlockDate
+  ) external nonReentrant returns (uint256) {
+    /// @dev increment our counter by 1
+    _tokenIds.increment();
+    /// @dev set our newItemID do the current counter uint
+    uint256 newItemId = _tokenIds.current();
+    /// @dev require that the amount is not 0, address is not the 0 address, and that the expiration date is actually beyond now
+    require(_amount > 0 && _token != address(0) && _unlockDate > block.timestamp, 'NFT01');
+    /// @dev using the same newItemID we generate a Future struct recording the token address (asset), the amount of tokens (amount), and time it can be unlocked (_unlockDate)
+    futures[newItemId] = Future(_amount, _token, _unlockDate);
+    /// @dev pulls funds from the msg.sender into this contract for escrow to be locked until the unlockDate has passed
+    TransferHelper.transferTokens(_token, msg.sender, address(this), _amount);
+    /// @dev this safely mints an NFT to the _holder address at the current counter index newItemID.
+    /// @dev _safeMint ensures that the receiver address can receive and handle ERC721s - which is either a normal wallet, or a smart contract that has implemented ERC721 receiver
+    _safeMint(_holder, newItemId);
+    /// @dev emit an event with the details of the NFT id minted, plus the attributes of the locked tokens
+    emit NFTCreated(newItemId, _holder, _amount, _token, _unlockDate);
+    return newItemId;
+  }
+
+  /// @dev internal function used by the standard ER721 function tokenURI to retrieve the baseURI privately held to visualize and get the metadata
+  function _baseURI() internal view override returns (string memory) {
+    return baseURI;
+  }
+
+  /// @notice function to set the base URI after the contract has been launched, only once - this is done by the admin
+  /// @notice there is no actual on-chain functions that require this URI to be anything beyond a blank string ("")
+  /// @param _uri is the
+  function updateBaseURI(string memory _uri) external {
+    /// @dev this function can only be called once - when the public variable uriSet is set to 0
+    require(uriSet == 0, 'NFT02');
+    /// @dev update the baseURI with the new _uri
+    baseURI = _uri;
+    /// @dev set the public variable uriSet to 1 so that this function cannot be called anymore
+    /// @dev cheaper to use uint8 than bool for this admin safety feature
+    uriSet = 1;
+    /// @dev emit event of the update uri
+    emit URISet(_uri);
+  }
+
+  /// @notice this is the external function that actually redeems an NFT position
+  /// @notice returns true if the function is successful
+  /// @dev this function calls the _redeemFuture(...) internal function which handles the requirements and checks
+  function redeemNFT(uint256 _id) external nonReentrant returns (bool) {
+    /// @dev calls the internal _redeemNFT function that performs various checks to ensure that only the owner of the NFT can redeem their NFT and Future position
+    _redeemNFT(payable(msg.sender), _id);
+    return true;
+  }
+
+  /**
+   * @notice This internal function, called by redeemNFT to physically burn the NFT and redeem their Future position which distributes the locked tokens to its owner
+   * @dev this function does five things: 1) Checks to ensure only the owner of the NFT can call this function
+   * @dev 2) it checks that the tokens can actually be unlocked based on the time from the expiration
+   * @dev 3) it burns the NFT - removing it from storage entirely
+   * @dev 4) it also deletes the futures struct from storage so that nothing can be redeemed from that storage index again
+   * @dev 5) it withdraws the tokens that have been locked - delivering them to the current owner of the NFT
+   * @param _holder is the owner of the NFT calling the function
+   * @param _id is the unique id of the NFT and unique id of the Future struct
+   */
+  function _redeemNFT(address payable _holder, uint256 _id) internal {
+    /// @dev ensure that only the owner of the NFT can call this function
+    require(ownerOf(_id) == _holder, 'NFT03');
+    /// @dev pull the future data from storage and keep in memory to check requirements and disribute tokens
+    Future memory future = futures[_id];
+    /// @dev ensure that the unlockDate is in the past compared to block.timestamp
+    /// @dev ensure that the future has not been redeemed already and that the amount is greater than 0
+    require(future.unlockDate < block.timestamp && future.amount > 0, 'NFT04');
+    /// @dev emit an event of the redemption, the id of the NFt and details of the future (locked tokens)  - needs to happen before we delete the future struct and burn the NFT
+    emit NFTRedeemed(_id, _holder, future.amount, future.token, future.unlockDate);
+    /// @dev burn the NFT
+    _burn(_id);
+    /// @dev delete the futures struct so that the owner cannot call this function again
+    delete futures[_id];
+    /// @dev physically deliver the tokens to the NFT owner
+    TransferHelper.withdrawPayment(weth, future.token, _holder, future.amount);
+  }
+
+  ///@notice Events when a new NFT (future) is created and one with a Future is redeemed (burned)
+  event NFTCreated(uint256 _i, address _holder, uint256 _amount, address _token, uint256 _unlockDate);
+  event NFTRedeemed(uint256 _i, address _holder, uint256 _amount, address _token, uint256 _unlockDate);
+  event URISet(string newURI);
+}


### PR DESCRIPTION
updated the contracts with some additional methods for redeeming and revoking all of the tokens associated with a given address.

added in ability to lock tokens for the vesting, so that a holder is prevented from redeeming until it is unlocked, whereupon they can redeem anything vested. If the manager revokes the token before unlocking, then any vested amount of tokens will be locked inside a hedgeys NFT. 